### PR TITLE
Use Vercel /tmp for signup SQLite database

### DIFF
--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -1,13 +1,17 @@
 import sqlite3 from 'sqlite3';
 import path from 'path';
-
-const dbPath = path.join(process.cwd(), 'data', 'signups.db');
-
-// Ensure data directory exists
 import fs from 'fs';
-const dataDir = path.dirname(dbPath);
-if (!fs.existsSync(dataDir)) {
-  fs.mkdirSync(dataDir, { recursive: true });
+
+const isVercel = process.env.VERCEL === '1';
+const dataRoot = isVercel ? '/tmp' : path.join(process.cwd(), 'data');
+const dbPath = path.join(dataRoot, 'signups.db');
+
+// Ensure data directory exists (only needed outside Vercel's writable /tmp)
+if (!isVercel) {
+  const dataDir = path.dirname(dbPath);
+  if (!fs.existsSync(dataDir)) {
+    fs.mkdirSync(dataDir, { recursive: true });
+  }
 }
 
 // Create database connection


### PR DESCRIPTION
### Motivation
- Deployments were failing when the app attempted to write the SQLite file to the read-only deployment filesystem on Vercel.
- use Vercel's writable `/tmp` directory during deployments while preserving local `data/` storage for development runs.
- Prevent runtime SQLite open/insert errors caused by attempting to create directories on a read-only FS.

### Description
- Detect Vercel runtime by checking `process.env.VERCEL === '1'` in `src/lib/database.ts` and set `dataRoot` to `/tmp` when running on Vercel.
- Build `dbPath` from the chosen `dataRoot` and only create the `data` directory when not running on Vercel to avoid write attempts to the deployment filesystem.
- Keep the existing database initialization and exported functions unchanged so behavior is consistent across environments.

### Testing
- Ran `npm run build` (Next.js `next build`) during investigation and it compiled successfully.
- Ran `npx prisma generate` and the Prisma Client was generated successfully.
- No additional automated CI tests were executed after this change was committed in this workspace.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963d80152208320a492f046822f22b9)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved database initialization to properly handle different deployment environments, ensuring correct data storage configuration across local and cloud deployments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->